### PR TITLE
Show not eligible screen if no eligible officers

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/CompanyConfirmationPageController.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/CompanyConfirmationPageController.java
@@ -85,6 +85,10 @@ public class CompanyConfirmationPageController extends BaseController {
             }
 
             returnedRequest = emergencyAuthCodeService.createAuthCodeRequest(eacRequest);
+            // If the response from creating the AuthCodeRequest is null the company had no eligible directors
+            if (returnedRequest == null) {
+                return UrlBasedViewResolver.REDIRECT_URL_PREFIX + "/auth-code-requests/company/" + companyNumber + CANNOT_USE_THIS_SERVICE;
+            }
             requestId = extractIdFromSelfLink(returnedRequest.getLinks());
 
             return navigatorService.getNextControllerRedirect(this.getClass(), requestId);

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImpl.java
@@ -44,6 +44,9 @@ public class EmergencyAuthCodeServiceImpl implements EmergencyAuthCodeService {
                     .createAuthCode(uri, privateEACRequestApi).execute();
             return eacRequestTransformer.apiToClient(apiResponse.getData());
         } catch (ApiErrorResponseException ex) {
+            if (ex.getStatusCode() == 404) {
+                return null;
+            }
             throw new ServiceException("Error creating emergency auth code request", ex);
         } catch (URIValidationException ex) {
             throw new ServiceException("Invalid URI for emergency auth code request", ex);

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.web.emergencyauthcodeweb.service.emergencyauthcode.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriTemplate;
 import uk.gov.companieshouse.api.InternalApiClient;
@@ -44,7 +45,7 @@ public class EmergencyAuthCodeServiceImpl implements EmergencyAuthCodeService {
                     .createAuthCode(uri, privateEACRequestApi).execute();
             return eacRequestTransformer.apiToClient(apiResponse.getData());
         } catch (ApiErrorResponseException ex) {
-            if (ex.getStatusCode() == 404) {
+            if (ex.getStatusCode() == HttpStatus.NOT_FOUND.value()) {
                 return null;
             }
             throw new ServiceException("Error creating emergency auth code request", ex);

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/CompanyConfirmationPageControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/CompanyConfirmationPageControllerTest.java
@@ -158,6 +158,23 @@ public class CompanyConfirmationPageControllerTest {
     }
 
     @Test
+    @DisplayName("Post to cannot use service page - no eligible officers found")
+    void postRequestNoEligibleDirectors() throws Exception {
+        when(mockEACService.createAuthCodeRequest(any(EACRequest.class))).thenReturn(null);
+
+        CompanyDetail validCompanyTypeAndStatus= new CompanyDetail();
+        validCompanyTypeAndStatus.setType(VALID_COMPANY_TYPE);
+        validCompanyTypeAndStatus.setCompanyStatus(VALID_COMPANY_STATUS);
+
+        when(mockCompanyService.getCompanyDetail(COMPANY_NUMBER)).thenReturn(validCompanyTypeAndStatus);
+
+        this.mockMvc.perform(post(EAC_COMPANY_CONFIRMATION_PATH))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name(EAC_CANNOT_USE_SERVICE_PATH));
+
+    }
+
+    @Test
     @DisplayName("Get company information view - Throws exception")
     void getRequestThrowsException() throws Exception {
         doThrow(ServiceException.class).when(mockCompanyService).getCompanyDetail(COMPANY_NUMBER);


### PR DESCRIPTION
If the emergency-auth-code-api returns a 404 no eligible officers were found so show the relevant page. 

Resolves: BI-3543