### PR TITLE
Update API with selected officer and populate officers details on confirm officer screen

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/ListOfOfficersController.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/ListOfOfficersController.java
@@ -57,9 +57,29 @@ public class ListOfOfficersController extends BaseController {
 
 
     @PostMapping
-    public String postListOfOfficers(@PathVariable String requestId, @ModelAttribute("eacOfficer") EACOfficer eacOfficer) {
-        String id = eacOfficer.getId();
-        LOGGER.info("ID OF THE SELECTED OFFICER: " + id);
+    public String postListOfOfficers(@PathVariable String requestId,
+                                     @ModelAttribute("eacOfficer") EACOfficer eacOfficer,
+                                     HttpServletRequest request) {
+
+        // Retrieve company number from API for later request
+        String companyNumber;
+        try {
+            companyNumber = emergencyAuthCodeService.getEACRequest(requestId).getCompanyNumber();
+        } catch (ServiceException ex) {
+            LOGGER.errorRequest(request, ex.getMessage(), ex);
+            return ERROR_VIEW;
+        }
+
+        EACRequest eacRequest = new EACRequest();
+        eacRequest.setOfficerId(eacOfficer.getId());
+        eacRequest.setCompanyNumber(companyNumber);
+
+        // Update API with selected officer
+        try {
+            emergencyAuthCodeService.updateEACRequest(requestId, eacRequest);
+        } catch (ServiceException ex) {
+            LOGGER.errorRequest(request, ex.getMessage(), ex);
+        }
 
         return navigatorService.getNextControllerRedirect(this.getClass(), requestId);
     }

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/ListOfOfficersController.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/ListOfOfficersController.java
@@ -79,6 +79,7 @@ public class ListOfOfficersController extends BaseController {
             emergencyAuthCodeService.updateEACRequest(requestId, eacRequest);
         } catch (ServiceException ex) {
             LOGGER.errorRequest(request, ex.getMessage(), ex);
+            return ERROR_VIEW;
         }
 
         return navigatorService.getNextControllerRedirect(this.getClass(), requestId);

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
@@ -41,7 +41,7 @@ public class OfficerConfirmationPageController extends BaseController {
         try {
             // Retrieve details for the selected officer from the API
             EACRequest eacRequest = emergencyAuthCodeService.getEACRequest(requestId);
-            if (eacRequest.getStatus().equals("sent")) {
+            if (eacRequest.getStatus().equals("submitted")) {
                 LOGGER.errorRequest(request, "Emergency Auth Code request has already been sent for this session");
                 return ERROR_VIEW;
             }

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
@@ -16,6 +16,9 @@ import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.re
 import uk.gov.companieshouse.web.emergencyauthcodeweb.service.emergencyauthcode.EmergencyAuthCodeService;
 
 import javax.servlet.http.HttpServletRequest;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 @Controller
 @PreviousController(ListOfOfficersController.class)
@@ -47,6 +50,9 @@ public class OfficerConfirmationPageController extends BaseController {
             addBackPageAttributeToModel(model, requestId);
 
             model.addAttribute("eacOfficer", eacOfficer);
+            model.addAttribute("eacRequest", eacRequest);
+            model.addAttribute("eacOfficerDOBMonth", Month.of(Integer.parseInt(eacOfficer.getDateOfBirth().getMonth())));
+            model.addAttribute("eacOfficerAppointment", DateTimeFormatter.ofPattern("dd MMMM yyyy", Locale.ENGLISH).format(eacOfficer.getAppointedOn()));
         } catch (ServiceException ex) {
             LOGGER.errorRequest(request, ex.getMessage(), ex);
             return ERROR_VIEW;

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/EmergencyAuthCodeService.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/EmergencyAuthCodeService.java
@@ -15,5 +15,5 @@ public interface EmergencyAuthCodeService {
 
     EACRequest getEACRequest(String requestId) throws ServiceException;
 
-    public Void updateEACRequest(String requestId, EACRequest eacRequest) throws ServiceException;
+    Void updateEACRequest(String requestId, EACRequest eacRequest) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/EmergencyAuthCodeService.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/EmergencyAuthCodeService.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.web.emergencyauthcodeweb.service.emergencyauthcode;
 
 import uk.gov.companieshouse.web.emergencyauthcodeweb.exception.ServiceException;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficer;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficerList;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.request.EACRequest;
 
@@ -10,5 +11,9 @@ public interface EmergencyAuthCodeService {
 
     EACOfficerList getListOfOfficers(String companyNumber) throws ServiceException;
 
+    EACOfficer getOfficer(String companyNumber, String officerId) throws ServiceException;
+
     EACRequest getEACRequest(String requestId) throws ServiceException;
+
+    public Void updateEACRequest(String requestId, EACRequest eacRequest) throws ServiceException;
 }

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImpl.java
@@ -9,19 +9,23 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.emergencyauthcode.authcoderequest.PrivateEACRequestApi;
+import uk.gov.companieshouse.api.model.emergencyauthcode.officer.PrivateEACOfficerApi;
 import uk.gov.companieshouse.api.model.emergencyauthcode.officer.PrivateEACOfficersListApi;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.api.ApiClientService;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.exception.ServiceException;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficer;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficerList;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.request.EACRequest;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.service.emergencyauthcode.EmergencyAuthCodeService;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthcode.officer.EACOfficerListTransformer;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthcode.officer.EACOfficerTransformer;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthcode.request.EACRequestTransformer;
 
 @Service
 public class EmergencyAuthCodeServiceImpl implements EmergencyAuthCodeService {
 
     private static final UriTemplate GET_OFFICERS_URI = new UriTemplate("/emergency-auth-code-service/company/{companyNumber}/officers");
+    private static final UriTemplate GET_OFFICER_URI = new UriTemplate("/emergency-auth-code-service/company/{companyNumber}/officers/{officerId}");
     private static final UriTemplate EMERGENCY_AUTH_CODE_REQUEST_URI = new UriTemplate("/emergency-auth-code-service/auth-code-requests");
     private static final UriTemplate GET_EMERGENCY_AUTH_CODE_REQUEST_URI = new UriTemplate("/emergency-auth-code-service/auth-code-requests/{requestId}");
 
@@ -33,6 +37,9 @@ public class EmergencyAuthCodeServiceImpl implements EmergencyAuthCodeService {
 
     @Autowired
     private EACOfficerListTransformer eacOfficerListTransformer;
+
+    @Autowired
+    private EACOfficerTransformer eacOfficerTransformer;
 
     public EACRequest createAuthCodeRequest(EACRequest eacRequest) throws ServiceException {
         PrivateEACRequestApi privateEACRequestApi = eacRequestTransformer.clientToApi(eacRequest);
@@ -69,6 +76,21 @@ public class EmergencyAuthCodeServiceImpl implements EmergencyAuthCodeService {
         }
     }
 
+    public EACOfficer getOfficer(String companyNumber, String officerId) throws ServiceException {
+        InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
+        ApiResponse<PrivateEACOfficerApi> apiResponse;
+
+        try {
+            String uri = GET_OFFICER_URI.expand(companyNumber, officerId).toString();
+            apiResponse = internalApiClient.privateEacResourceHandler().getOfficer(uri).execute();
+            return eacOfficerTransformer.apiToClient(apiResponse.getData());
+        } catch (ApiErrorResponseException ex) {
+            throw new ServiceException("Error retrieving selected officer for company", ex);
+        } catch (URIValidationException ex) {
+            throw new ServiceException("Invalid URI for retrieving selected officer for company", ex);
+        }
+    }
+
     public EACRequest getEACRequest(String requestId) throws ServiceException {
         InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
         ApiResponse<PrivateEACRequestApi> apiResponse;
@@ -81,6 +103,21 @@ public class EmergencyAuthCodeServiceImpl implements EmergencyAuthCodeService {
             throw new ServiceException("Error retrieving emergency auth code request", ex);
         } catch (URIValidationException ex) {
             throw new ServiceException("Invalid URI for retrieving emergency auth code request", ex);
+        }
+    }
+
+    public Void updateEACRequest(String requestId, EACRequest eacRequest) throws ServiceException {
+        PrivateEACRequestApi privateEACRequestApi = eacRequestTransformer.clientToApi(eacRequest);
+
+        InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
+        try {
+            String uri = GET_EMERGENCY_AUTH_CODE_REQUEST_URI.expand(requestId).toString();
+            return internalApiClient.privateEacResourceHandler()
+                    .updateAuthCode(uri, privateEACRequestApi).execute().getData();
+        } catch (ApiErrorResponseException ex) {
+            throw new ServiceException("Error creating emergency auth code request", ex);
+        } catch (URIValidationException ex) {
+            throw new ServiceException("Invalid URI for emergency auth code request", ex);
         }
     }
 }

--- a/src/main/resources/templates/eac/officerConfirmation.html
+++ b/src/main/resources/templates/eac/officerConfirmation.html
@@ -25,54 +25,42 @@
                         <dt class="govuk-summary-list__key">
                             Role
                         </dt>
-                        <dd class="govuk-summary-list__value">
-                            Director
-                        </dd>
+                        <dd class="govuk-summary-list__value" th:id="${eacOfficer.officerRole}" th:text="${eacOfficer.officerRole}"></dd>
                     </div>
 
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Date of birth
                         </dt>
-                        <dd class="govuk-summary-list__value">
-                            December 1952
-                        </dd>
+                        <dd class="govuk-summary-list__value" th:id="${eacOfficerDOBMonth} + ' ' + ${eacOfficer.dateOfBirth.year}" th:text="${eacOfficerDOBMonth} + ' ' + ${eacOfficer.dateOfBirth.year}"></dd>
                     </div>
 
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Appointed on
                         </dt>
-                        <dd class="govuk-summary-list__value">
-                            13 May 2015
-                        </dd>
+                        <dd class="govuk-summary-list__value" th:id="${eacOfficerAppointment}" th:text="${eacOfficerAppointment}"></dd>
                     </div>
 
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Nationality
                         </dt>
-                        <dd class="govuk-summary-list__value">
-                            British
-                        </dd>
+                        <dd class="govuk-summary-list__value" th:id="${eacOfficer.nationality}" th:text="${eacOfficer.nationality}"></dd>
                     </div>
 
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Country of residence
                         </dt>
-                        <dd class="govuk-summary-list__value">
-                            United Kingdom
-                        </dd>
+                        <dd class="govuk-summary-list__value" th:id="${eacOfficer.countryOfResidence}" th:text="${eacOfficer.countryOfResidence}"></dd>
                     </div>
 
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">
                             Occupation
                         </dt>
-                        <dd class="govuk-summary-list__value">
-                            Chartered Accountant
-                        </dd>
+                        <dd class="govuk-summary-list__value" th:id="${eacOfficer.occupation}" th:text="${eacOfficer.occupation}"></dd>
                     </div>
                 </dl>
                 <div class="form-group">
@@ -81,8 +69,8 @@
                         <div class="govuk-checkboxes govuk-checkboxes--small">
                             <div class="govuk-checkboxes__item">
                                 <input class="govuk-checkboxes__input" id="organisation" name="organisation" type="checkbox" value="hmrc">
-                                <label class="govuk-label govuk-checkboxes__label" for="organisation">
-                                    I confirm that I want the authentication code sent to the most recent home address given to Companies House for Joe Root Bloggs
+                                <label class="govuk-label govuk-checkboxes__label" for="organisation"
+                                       th:text="'I confirm that I want the authentication code sent to the most recent home address given to Companies House for ' + ${eacRequest.officerName}">
                                 </label>
                             </div>
                         </div>

--- a/src/main/resources/templates/eac/officerConfirmation.html
+++ b/src/main/resources/templates/eac/officerConfirmation.html
@@ -18,9 +18,7 @@
                         <dt class="govuk-summary-list__key">
                             Name
                         </dt>
-                        <dd class="govuk-summary-list__value">
-                            BLOGGS, Joe Root
-                        </dd>
+                        <dd class="govuk-summary-list__value" th:id="${eacOfficer.id}" th:text="${eacOfficer.name}"></dd>
 
                     </div>
                     <div class="govuk-summary-list__row">

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/ListOfOfficersControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/ListOfOfficersControllerTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.exception.ServiceException;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficerList;

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
@@ -10,7 +10,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.UrlBasedViewResolver;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.exception.ServiceException;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficer;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficerDOB;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficerList;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.request.EACRequest;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.service.emergencyauthcode.EmergencyAuthCodeService;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.service.navigation.NavigatorService;
+
+import java.time.LocalDate;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -22,13 +30,28 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(MockitoExtension.class)
 public class OfficerConfirmationPageControllerTest {
-    private static final String EAC_OFFICER_CONFIRMATION_PATH = "/auth-code-requests/requests/request_id_placeholder/confirm-officer";
+    private static final String REQUEST_ID = "abc123";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String OFFICER_ID = "87654321";
+    private static final String EAC_OFFICER_CONFIRMATION_PATH = "/auth-code-requests/requests/" + REQUEST_ID + "/confirm-officer";
     private static final String EAC_OFFICER_CONFIRMATION_VIEW = "eac/officerConfirmation";
+    private static final String ERROR = "error";
     private static final String MOCK_CONTROLLER_PATH = UrlBasedViewResolver.REDIRECT_URL_PREFIX + "mockControllerPath";
 
     private static final String BACK_BUTTON_MODEL_ATTR = "backButton";
+    private static final String EAC_OFFICER_MODEL_ATTR = "eacOfficer";
+    private static final String EAC_REQUEST_MODEL_ATTR = "eacRequest";
+    private static final String EAC_OFFICER_DOB_MONTH_MODEL_ATTR = "eacOfficerDOBMonth";
+    private static final String EAC_OFFICER_APPOINTMENT_MODEL_ATTR = "eacOfficerAppointment";
+
 
     private MockMvc mockMvc;
+    private EACRequest eacRequest = new EACRequest();
+    private EACOfficer eacOfficer = new EACOfficer();
+    private EACOfficerDOB eacOfficerDOB = new EACOfficerDOB();
+
+    @Mock
+    private EmergencyAuthCodeService emergencyAuthCodeService;
 
     @Mock
     private NavigatorService navigatorService;
@@ -42,15 +65,51 @@ public class OfficerConfirmationPageControllerTest {
     }
 
     @Test
+    @DisplayName("Get list of officers view - request already marked as submitted")
+    void getRequestEACRequestAlreadySent() throws Exception {
+        eacRequest.setStatus("submitted");
+        eacRequest.setCompanyNumber(COMPANY_NUMBER);
+        eacRequest.setOfficerId(OFFICER_ID);
+        when(emergencyAuthCodeService.getEACRequest(REQUEST_ID)).thenReturn(eacRequest);
+
+        this.mockMvc.perform(get(EAC_OFFICER_CONFIRMATION_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR));
+    }
+
+    @Test
+    @DisplayName("Get list of officers view - error returning request from API")
+    void getRequestErrorReturningEACRequest() throws Exception {
+        when(emergencyAuthCodeService.getEACRequest(REQUEST_ID)).thenThrow(ServiceException.class);
+
+        this.mockMvc.perform(get(EAC_OFFICER_CONFIRMATION_PATH))
+                .andExpect(status().isOk())
+                .andExpect(view().name(ERROR));
+    }
+
+    @Test
     @DisplayName("Get list of officers view - successful")
     void getRequestSuccessful() throws Exception {
-        when(navigatorService.getPreviousControllerPath(any(), any()))
-                .thenReturn(MOCK_CONTROLLER_PATH);
+        eacRequest.setStatus("pending");
+        eacRequest.setCompanyNumber(COMPANY_NUMBER);
+        eacRequest.setOfficerId(OFFICER_ID);
+        when(emergencyAuthCodeService.getEACRequest(REQUEST_ID)).thenReturn(eacRequest);
+
+        eacOfficerDOB.setMonth("1");
+        eacOfficer.setDateOfBirth(eacOfficerDOB);
+        eacOfficer.setAppointedOn(LocalDate.of(2020, 1, 1));
+        when(emergencyAuthCodeService.getOfficer(COMPANY_NUMBER, OFFICER_ID)).thenReturn(eacOfficer);
+
+        when(navigatorService.getPreviousControllerPath(any(), any())).thenReturn(MOCK_CONTROLLER_PATH);
 
         this.mockMvc.perform(get(EAC_OFFICER_CONFIRMATION_PATH))
                 .andExpect(status().isOk())
                 .andExpect(view().name(EAC_OFFICER_CONFIRMATION_VIEW))
-                .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR));
+                .andExpect(model().attributeExists(BACK_BUTTON_MODEL_ATTR))
+                .andExpect(model().attributeExists(EAC_OFFICER_MODEL_ATTR))
+                .andExpect(model().attributeExists(EAC_REQUEST_MODEL_ATTR))
+                .andExpect(model().attributeExists(EAC_OFFICER_DOB_MONTH_MODEL_ATTR))
+                .andExpect(model().attributeExists(EAC_OFFICER_APPOINTMENT_MODEL_ATTR));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImplTest.java
@@ -29,6 +29,7 @@ import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthc
 import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthcode.request.EACRequestTransformer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
@@ -278,7 +279,7 @@ public class EmergencyAuthCodeServiceImplTest {
         when(eacUpdateRequestApiResponse.getData()).thenReturn(null);
 
         Void result = eacService.updateEACRequest(EAC_REQUEST_ID, eacRequest);
-        assertEquals(null, result);
+        assertNull(result);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/service/emergencyauthcode/impl/EmergencyAuthCodeServiceImplTest.java
@@ -9,18 +9,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.emergencyauthcode.PrivateEACResourceHandler;
+import uk.gov.companieshouse.api.handler.emergencyauthcode.request.PrivateEACOfficerGet;
 import uk.gov.companieshouse.api.handler.emergencyauthcode.request.PrivateEACOfficerList;
 import uk.gov.companieshouse.api.handler.emergencyauthcode.request.PrivateEACRequestCreate;
 import uk.gov.companieshouse.api.handler.emergencyauthcode.request.PrivateEACRequestGet;
+import uk.gov.companieshouse.api.handler.emergencyauthcode.request.PrivateEACRequestUpdate;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.api.model.emergencyauthcode.authcoderequest.PrivateEACRequestApi;
+import uk.gov.companieshouse.api.model.emergencyauthcode.officer.PrivateEACOfficerApi;
 import uk.gov.companieshouse.api.model.emergencyauthcode.officer.PrivateEACOfficersListApi;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.api.ApiClientService;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.exception.ServiceException;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficer;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.officer.EACOfficerList;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.model.emergencyauthcode.request.EACRequest;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthcode.officer.EACOfficerListTransformer;
+import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthcode.officer.EACOfficerTransformer;
 import uk.gov.companieshouse.web.emergencyauthcodeweb.transformer.emergencyauthcode.request.EACRequestTransformer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,11 +42,16 @@ public class EmergencyAuthCodeServiceImplTest {
     private static final String COMPANY_NUMBER = "12345678";
     private static final String LIST_OFFICERS_URI = "/emergency-auth-code-service/company/" + COMPANY_NUMBER + "/officers";
 
+    private static final String OFFICER_ID = "87654321";
+    private static final String GET_OFFICER_URI = LIST_OFFICERS_URI + "/" + OFFICER_ID;
+
     private EACRequest eacRequest = new EACRequest();
     private PrivateEACRequestApi eacRequestApi = new PrivateEACRequestApi();
 
     private EACOfficerList eacOfficerList = new EACOfficerList();
     private PrivateEACOfficersListApi eacOfficersListApi = new PrivateEACOfficersListApi();
+    private EACOfficer eacOfficer = new EACOfficer();
+    private PrivateEACOfficerApi eacOfficerApi = new PrivateEACOfficerApi();
 
     @Mock
     private InternalApiClient internalApiClient;
@@ -62,7 +72,19 @@ public class EmergencyAuthCodeServiceImplTest {
     private PrivateEACOfficerList privateEACOfficerList;
 
     @Mock
+    private PrivateEACOfficerGet privateEACOfficerGet;
+
+    @Mock
+    private PrivateEACRequestUpdate privateEACRequestUpdate;
+
+    @Mock
     private ApiResponse<PrivateEACOfficersListApi> eacOfficersListApiResponse;
+
+    @Mock
+    private ApiResponse<PrivateEACOfficerApi> eacOfficerApiResponse;
+
+    @Mock
+    private ApiResponse<Void> eacUpdateRequestApiResponse;
 
     @Mock
     private ApiClientService apiClientService;
@@ -72,6 +94,9 @@ public class EmergencyAuthCodeServiceImplTest {
 
     @Mock
     private EACOfficerListTransformer eacOfficerListTransformer;
+
+    @Mock
+    private EACOfficerTransformer eacOfficerTransformer;
 
     @InjectMocks
     private EmergencyAuthCodeServiceImpl eacService;
@@ -162,6 +187,45 @@ public class EmergencyAuthCodeServiceImplTest {
     }
 
     @Test
+    @DisplayName("Test get request for single officer is successful")
+    void testGetOfficer_Successful()
+            throws ApiErrorResponseException, URIValidationException, ServiceException {
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateEacResourceHandler()).thenReturn(privateEACResourceHandler);
+        when(privateEACResourceHandler.getOfficer(GET_OFFICER_URI)).thenReturn(privateEACOfficerGet);
+        when(privateEACOfficerGet.execute()).thenReturn(eacOfficerApiResponse);
+        when(eacOfficerApiResponse.getData()).thenReturn(eacOfficerApi);
+        when(eacOfficerTransformer.apiToClient(eacOfficerApi)).thenReturn(eacOfficer);
+
+        EACOfficer result = eacService.getOfficer(COMPANY_NUMBER, OFFICER_ID);
+        assertEquals(eacOfficer, result);
+    }
+
+    @Test
+    @DisplayName("Test get request for single officer is unsuccessful - ApiErrorResponseException")
+    void testGetOfficer_Unsuccessful_ApiErrorResponseException()
+            throws ApiErrorResponseException, URIValidationException {
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateEacResourceHandler()).thenReturn(privateEACResourceHandler);
+        when(privateEACResourceHandler.getOfficer(GET_OFFICER_URI)).thenReturn(privateEACOfficerGet);
+        when(privateEACOfficerGet.execute()).thenThrow(ApiErrorResponseException.class);
+
+        assertThrows(ServiceException.class, () -> eacService.getOfficer(COMPANY_NUMBER, OFFICER_ID));
+    }
+
+    @Test
+    @DisplayName("Test get request for list of officers is unsuccessful - URIValidationException")
+    void testGetOfficer_Unsuccessful_URIValidationException()
+            throws ApiErrorResponseException, URIValidationException {
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateEacResourceHandler()).thenReturn(privateEACResourceHandler);
+        when(privateEACResourceHandler.getOfficer(GET_OFFICER_URI)).thenReturn(privateEACOfficerGet);
+        when(privateEACOfficerGet.execute()).thenThrow(URIValidationException.class);
+
+        assertThrows(ServiceException.class, () -> eacService.getOfficer(COMPANY_NUMBER, OFFICER_ID));
+    }
+
+    @Test
     @DisplayName("Test get request for an emergency auth code request is successful")
     void testGetEACRequest_Successful()
             throws ApiErrorResponseException, URIValidationException, ServiceException {
@@ -198,5 +262,52 @@ public class EmergencyAuthCodeServiceImplTest {
         when(privateEACRequestGet.execute()).thenThrow(URIValidationException.class);
 
         assertThrows(ServiceException.class, () -> eacService.getEACRequest(EAC_REQUEST_ID));
+    }
+
+    @Test
+    @DisplayName("Test update existing emergency auth code request is successful")
+    void testEACUpdateRequest_Successful()
+            throws ApiErrorResponseException, URIValidationException, ServiceException {
+        when(eacRequestTransformer.clientToApi(eacRequest)).thenReturn(eacRequestApi);
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateEacResourceHandler()).thenReturn(privateEACResourceHandler);
+        when(privateEACResourceHandler
+                .updateAuthCode(GET_EMERGENCY_AUTH_CODE_REQUEST_URI, eacRequestApi))
+                .thenReturn(privateEACRequestUpdate);
+        when(privateEACRequestUpdate.execute()).thenReturn(eacUpdateRequestApiResponse);
+        when(eacUpdateRequestApiResponse.getData()).thenReturn(null);
+
+        Void result = eacService.updateEACRequest(EAC_REQUEST_ID, eacRequest);
+        assertEquals(null, result);
+    }
+
+    @Test
+    @DisplayName("Test update existing emergency auth code request is unsuccessful - ApiErrorResponseException")
+    void testEACUpdateRequest_Unsuccessful_ApiErrorResponseException()
+            throws ApiErrorResponseException, URIValidationException {
+        when(eacRequestTransformer.clientToApi(eacRequest)).thenReturn(eacRequestApi);
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateEacResourceHandler()).thenReturn(privateEACResourceHandler);
+        when(privateEACResourceHandler
+                .updateAuthCode(GET_EMERGENCY_AUTH_CODE_REQUEST_URI, eacRequestApi))
+                .thenReturn(privateEACRequestUpdate);
+        when(privateEACRequestUpdate.execute()).thenThrow(ApiErrorResponseException.class);
+
+        assertThrows(ServiceException.class, () -> eacService.updateEACRequest(EAC_REQUEST_ID, eacRequest));
+    }
+
+    @Test
+    @DisplayName("Test update existing emergency auth code request is unsuccessful - URIValidationException")
+    void testEACUpdateRequest_Unsuccessful_URIValidationException()
+            throws ApiErrorResponseException, URIValidationException {
+        when(eacRequestTransformer.clientToApi(eacRequest)).thenReturn(eacRequestApi);
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateEacResourceHandler()).thenReturn(privateEACResourceHandler);
+        when(privateEACResourceHandler
+                .updateAuthCode(GET_EMERGENCY_AUTH_CODE_REQUEST_URI, eacRequestApi))
+                .thenReturn(privateEACRequestUpdate);
+        when(privateEACRequestUpdate.execute()).thenThrow(URIValidationException.class);
+
+        assertThrows(ServiceException.class, () -> eacService.updateEACRequest(EAC_REQUEST_ID, eacRequest));
     }
 }


### PR DESCRIPTION
When the officer is selected from the officer list send the PUT request to update the API with the officer ID. 
Then on the following page display the officers details back to the user for confirmation. 

Resolves: BI-3547 and BI-3361

