### PR TITLE
BI-4815 check eac request status on an office confirmation post

### DIFF
--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
@@ -53,7 +53,7 @@ public class OfficerConfirmationPageController extends BaseController {
             EACRequest eacRequest = emergencyAuthCodeService.getEACRequest(requestId);
             if (eacRequest.getStatus().equals(SUBMITTED_STATUS)) {
                 LOGGER.errorRequest(request, "Emergency Auth Code request has already been sent for this session");
-                return ERROR_VIEW;
+                return CANNOT_USE_THIS_SERVICE;
             }
             EACOfficer eacOfficer = emergencyAuthCodeService.getOfficer(eacRequest.getCompanyNumber(), eacRequest.getOfficerId());
 

--- a/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
+++ b/src/main/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageController.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 public class OfficerConfirmationPageController extends BaseController {
     private static final String OFFICER_INFORMATION = "eac/officerConfirmation";
     private static final String OFFICER_CONFIRMATION_MODEL_ATTR = "officerConfirmation";
+    private static final String CANNOT_USE_THIS_SERVICE = "eac/cannotUseThisService";
 
     private static final String SUBMITTED_STATUS = "submitted";
 
@@ -88,6 +89,11 @@ public class OfficerConfirmationPageController extends BaseController {
 
         try {
             EACRequest eacRequest = emergencyAuthCodeService.getEACRequest(requestId);
+
+            if (eacRequest.getStatus().equals(SUBMITTED_STATUS)) {
+                LOGGER.errorRequest(request, "Emergency Auth Code request has already been sent for this session");
+                return CANNOT_USE_THIS_SERVICE;
+            }
 
             String companyNumber = eacRequest.getCompanyNumber();
             String officerId = eacRequest.getOfficerId();

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
@@ -49,7 +49,7 @@ public class OfficerConfirmationPageControllerTest {
     private static final String VALID_CONFIRMATION = "true";
 
     private MockMvc mockMvc;
-    private EACRequest eacRequest = new EACRequest();
+    private EACRequest eacRequest;
     private EACOfficer eacOfficer = new EACOfficer();
     private EACOfficerDOB eacOfficerDOB = new EACOfficerDOB();
 
@@ -65,6 +65,8 @@ public class OfficerConfirmationPageControllerTest {
     @BeforeEach
     void setUp() {
         this.mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        this.eacRequest = new EACRequest();
+        this.eacRequest.setStatus("pending");
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
@@ -77,7 +77,7 @@ public class OfficerConfirmationPageControllerTest {
 
         this.mockMvc.perform(get(EAC_OFFICER_CONFIRMATION_PATH))
                 .andExpect(status().isOk())
-                .andExpect(view().name(ERROR));
+                .andExpect(view().name(CANNOT_USE_THIS_SERVICE));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
@@ -42,6 +42,7 @@ public class OfficerConfirmationPageControllerTest {
     private static final String EAC_REQUEST_MODEL_ATTR = "eacRequest";
     private static final String EAC_OFFICER_DOB_MONTH_MODEL_ATTR = "eacOfficerDOBMonth";
     private static final String EAC_OFFICER_APPOINTMENT_MODEL_ATTR = "eacOfficerAppointment";
+    private static final String CANNOT_USE_THIS_SERVICE = "eac/cannotUseThisService";
 
 
     private static final String OFFICER_CONFIRMATION_PARAM = "confirm";
@@ -140,6 +141,17 @@ public class OfficerConfirmationPageControllerTest {
                 .param(OFFICER_CONFIRMATION_PARAM, VALID_CONFIRMATION))
                 .andExpect(status().isOk())
                 .andExpect(view().name(ERROR));
+    }
+
+    @Test
+    @DisplayName("Post to confirmation page - unsuccessful - emergencyAuthCodeService returns eac request with a SUBMITTED status")
+    void postRequestUnsuccessful_Submitted_Status_ServiceException() throws Exception {
+        when(emergencyAuthCodeService.getEACRequest(REQUEST_ID)).thenThrow(ServiceException.class);
+
+        this.mockMvc.perform(post(EAC_OFFICER_CONFIRMATION_PATH)
+                .param(OFFICER_CONFIRMATION_PARAM, VALID_CONFIRMATION))
+                .andExpect(status().isOk())
+                .andExpect(view().name(CANNOT_USE_THIS_SERVICE));
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/web/emergencyauthcodeweb/controller/eac/OfficerConfirmationPageControllerTest.java
@@ -148,7 +148,9 @@ public class OfficerConfirmationPageControllerTest {
     @Test
     @DisplayName("Post to confirmation page - unsuccessful - emergencyAuthCodeService returns eac request with a SUBMITTED status")
     void postRequestUnsuccessful_Submitted_Status_ServiceException() throws Exception {
-        when(emergencyAuthCodeService.getEACRequest(REQUEST_ID)).thenThrow(ServiceException.class);
+        eacRequest.setCompanyNumber(COMPANY_NUMBER);
+        eacRequest.setStatus("submitted");
+        when(emergencyAuthCodeService.getEACRequest(REQUEST_ID)).thenReturn(eacRequest);
 
         this.mockMvc.perform(post(EAC_OFFICER_CONFIRMATION_PATH)
                 .param(OFFICER_CONFIRMATION_PARAM, VALID_CONFIRMATION))


### PR DESCRIPTION
BI-4815 check the eac request status on a office confirmation page post and render the cannot use page if the status is submitted, also render the cannot use page on the get too if status is submitted