### PR TITLE
use latest dependency-check setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 artifact_name       := emergency-auth-code-web
 version             := "unversioned"
 
+dependency_check_base_suppressions:=common_suppressions_spring_6.xml
+dependency_check_suppressions_repo_branch:=main
+dependency_check_minimum_cvss := 4
+dependency_check_assembly_analyzer_enabled := false
+dependency_check_suppressions_repo_url:=git@github.com:companieshouse/dependency-check-suppressions.git
+suppressions_file := target/suppressions.xml
+
 .PHONY: all
 all: build
 
@@ -61,10 +68,6 @@ sonar:
 sonar-pr-analysis:
 	mvn sonar:sonar -P sonar-pr-analysis
 
-.PHONY: security-check
-security-check:
-	mvn org.owasp:dependency-check-maven:update-only
-	mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=4 -DassemblyAnalyzerEnabled=false
 
 .PHONY: build-image
 build-image:
@@ -79,3 +82,36 @@ all: clean build build-image
 .PHONY: run
 run:
 	docker run -it --rm $(artifact_name)
+
+.PHONY: dependency-check
+dependency-check:
+	@ if [ -d "$(DEPENDENCY_CHECK_SUPPRESSIONS_HOME)" ]; then \
+		suppressions_home="$${DEPENDENCY_CHECK_SUPPRESSIONS_HOME}"; \
+	fi; \
+	if [ ! -d "$${suppressions_home}" ]; then \
+	    suppressions_home_target_dir="./target/dependency-check-suppressions"; \
+		if [ -d "$${suppressions_home_target_dir}" ]; then \
+			suppressions_home="$${suppressions_home_target_dir}"; \
+		else \
+			mkdir -p "./target"; \
+			git clone $(dependency_check_suppressions_repo_url) "$${suppressions_home_target_dir}" && \
+				suppressions_home="$${suppressions_home_target_dir}"; \
+			if [ -d "$${suppressions_home_target_dir}" ] && [ -n "$(dependency_check_suppressions_repo_branch)" ]; then \
+				cd "$${suppressions_home}"; \
+				git checkout $(dependency_check_suppressions_repo_branch); \
+				cd -; \
+			fi; \
+		fi; \
+	fi; \
+	suppressions_path="$${suppressions_home}/suppressions/$(dependency_check_base_suppressions)"; \
+	if [  -f "$${suppressions_path}" ]; then \
+		cp -av "$${suppressions_path}" $(suppressions_file); \
+		mvn org.owasp:dependency-check-maven:check -Dformats="json,html" -DprettyPrint -DfailBuildOnCVSS=$(dependency_check_minimum_cvss) -DassemblyAnalyzerEnabled=$(dependency_check_assembly_analyzer_enabled) -DsuppressionFiles=$(suppressions_file); \
+	else \
+		printf -- "\n ERROR Cannot find suppressions file at '%s'\n" "$${suppressions_path}" >&2; \
+		exit 1; \
+	fi
+
+.PHONY: security-check
+security-check: dependency-check
+

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>2.1.6</version>
+        <version>2.1.11</version>
         <relativePath/>
     </parent>
 

--- a/suppress.xml
+++ b/suppress.xml
@@ -1,3 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-</suppressions>


### PR DESCRIPTION
5e481e4 Remove defunct suppress.xml
The suppress.xml file is now pulled from the
 dependency-check-suppressions repo.

073538d Point Makefile at dep-check-suppressions/main
Now gets suppressions from dependency-check-suppressions/main.
Tidied Makefile for dependency-check consistency
Removed extraneous comments.
Made line spacing, ordering, format for dependency-check sections
 identical across Makefiles.
Added json to dependency check report formats.

929f4d6 Update parent pom to 2.1.11
2.1.11 brings in latest correct dependency-check settings.

Fixes [CC-1897](https://companieshouse.atlassian.net/browse/CC-1897)

[CC-1897]: https://companieshouse.atlassian.net/browse/CC-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ