### PR TITLE
CC-2169: Remove COVID gov warning from confirmation page template.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
 
         <spring-boot-maven-plugin.version>3.3.3</spring-boot-maven-plugin.version>
-        <spring-boot.version>3.4.4</spring-boot.version>
+        <spring-boot.version>3.4.5</spring-boot.version>
         <spring-security-test.version>6.4.5</spring-security-test.version>
         <spring-security-config.version>6.4.5</spring-security-config.version>
         <spring-web.version>6.2.6</spring-web.version>

--- a/src/main/resources/templates/eac/confirmationPage.html
+++ b/src/main/resources/templates/eac/confirmationPage.html
@@ -28,13 +28,6 @@
                 </p>
                 <h2 class="govuk-heading-m">How long it takes</h2>
                 <p class="govuk-body">It takes around 5 working days for an authentication code to be delivered to an officer's home address.</p>
-                <div class="govuk-warning-text">
-                    <span style="top:10%;" class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong style="margin-left:auto;" class="govuk-warning-text__text">
-                        <span class="govuk-warning-text__assistive">Warning</span>
-                        Due to the impact of coronavirus (COVID-19) it may take longer than usual for post to be delivered.
-                    </strong>
-                </div>
 
                 <h2 class="govuk-heading-m">How to contact us</h2>
                 <p class="govuk-body">If delivery of the letter is taking longer than you'd expect, contact us.


### PR DESCRIPTION
As per title. Text to be removed:

![image](https://github.com/user-attachments/assets/ea8c339b-9def-468a-8154-e852420438b4)

Ticket -> https://companieshouse.atlassian.net/browse/CC-2169